### PR TITLE
Fixing extension name for newsholder page

### DIFF
--- a/_config/newsly.yml
+++ b/_config/newsly.yml
@@ -2,5 +2,5 @@
 name: 'newsly'
 ---
 NewsHolder:
-  extensions: 
-    - ExcludeChildren
+  extensions:
+    - Lumberjack


### PR DESCRIPTION
Hello @sheadawson 

The name of the extension wasn't correct as far as I can tell. Can you verify this and maybe merge it in?

Spek
